### PR TITLE
Colorpicker improvements

### DIFF
--- a/.config/waybar/scripts/colorpicker.sh
+++ b/.config/waybar/scripts/colorpicker.sh
@@ -18,6 +18,7 @@ limit=10
 
 [[ $# -eq 1 && $1 = "-j" ]] && {
   text="$(head -n 1 "$loc/colors")"
+  text=${text:-#FFFFFF} #if we start for the first time ever the file is empty and thus waybar will throw an error and not display the colorpicker. here is a fallback for that
 
   mapfile -t allcolors < <(tail -n +2 "$loc/colors")
   # allcolors=($(tail -n +2 "$loc/colors"))

--- a/.config/waybar/scripts/colorpicker.sh
+++ b/.config/waybar/scripts/colorpicker.sh
@@ -47,8 +47,14 @@ check wl-copy && {
 }
 
 prevColors=$(head -n $((limit - 1)) "$loc/colors")
+
+color_preview=$wallpaper
+check magick && {
+  magick -size 64x64 canvas:"$color" "$loc/color_preview.png"
+  color_preview="$loc/color_preview.png"
+}
 echo "$color" >"$loc/colors"
 echo "$prevColors" >>"$loc/colors"
 sed -i '/^$/d' "$loc/colors"
-source ~/.cache/wal/colors.sh && notify-send "Color Picker" "This color has been selected: $color" -i $wallpaper
+source ~/.cache/wal/colors.sh && notify-send "Color Picker" "This color has been selected: $color" -i $color_preview
 pkill -RTMIN+1 waybar


### PR DESCRIPTION
### A PR for Dotfiles?? WHaaa-

Yes... I know. These are your dotfiles and no one should touch them. However the color picker was a bit annoying and a bit to messy for my liking so i changed some code. And i thought why not PR so everyone can benefit.

#### This PR proposes:
- Tiny fix for first ever boot.
after assigning to text, we check if text is empty, if so we fallback to a default white:
`text=${text:-#FFFFFF}`
this fixes:
`...should be a color specification, not ''`

- Actual color as thumbnail for notification:
We do this with the help of magick (if magick does not pass your `check()` we fall back to default behaviour):
```bash
color_preview=$wallpaper
check magick && {
  magick -size 64x64 canvas:"$color" "$loc/color_preview.png"
  color_preview="$loc/color_preview.png"
}
```
and later on we just pass `-i $color_preview`

This is how it looks:
![image](https://github.com/user-attachments/assets/5a8c54e1-c445-4ef5-870d-dbfa2385faff)
